### PR TITLE
Feature/aggregator tunnel sessions

### DIFF
--- a/plugins/aggregator.rb
+++ b/plugins/aggregator.rb
@@ -6,7 +6,7 @@
 #
 # $Revision$
 #
-require "msf/aggregator"
+require "metasploit/aggregator"
 
 module Msf
   Aggregator_yaml = "#{Msf::Config.get_config_root}/aggregator.yaml" #location of the aggregator.yml containing saved aggregator creds
@@ -203,7 +203,7 @@ class Plugin::Aggregator < Msf::Plugin
       if certificate && File.exists?(certificate)
         certificate = File.new(certificate).read
       end
-      @aggregator.add_cable(Msf::Aggregator::Cable::HTTPS, host, port, certificate)
+      @aggregator.add_cable(Metasploit::Aggregator::Cable::HTTPS, host, port, certificate)
     end
 
     def cmd_aggregator_cables
@@ -345,7 +345,7 @@ class Plugin::Aggregator < Msf::Plugin
 
       begin
         print_status("Connecting to Aggregator instance at #{@host}:#{@port}...")
-        @aggregator = Msf::Aggregator::ServerProxy.new(@host, @port)
+        @aggregator = Metasploit::Aggregator::ServerProxy.new(@host, @port)
       end
 
       aggregator_compatibility_check
@@ -394,8 +394,8 @@ class Plugin::Aggregator < Msf::Plugin
           'RunAsJob' => true
       )
       @payload_job_ids << multi_handler.job_id
-      # requester = Msf::Aggregator::Http::SslRequester.new(multi_handler.datastore['LHOST'], multi_handler.datastore['LPORT'])
-      requester = Msf::Aggregator::Http::Requester.new(multi_handler.datastore['LHOST'], multi_handler.datastore['LPORT'])
+      # requester = Metasploit::Aggregator::Http::SslRequester.new(multi_handler.datastore['LHOST'], multi_handler.datastore['LPORT'])
+      requester = Metasploit::Aggregator::Http::Requester.new(multi_handler.datastore['LHOST'], multi_handler.datastore['LPORT'])
       requester
     end
 

--- a/plugins/aggregator.rb
+++ b/plugins/aggregator.rb
@@ -10,7 +10,6 @@ require "msf/aggregator"
 
 module Msf
   Aggregator_yaml = "#{Msf::Config.get_config_root}/aggregator.yaml" #location of the aggregator.yml containing saved aggregator creds
-  Aggregator_Temp = "#{Msf::Config.get_config_root}/aggregator.temp"
 
 class Plugin::Aggregator < Msf::Plugin
   class AggregatorCommandDispatcher


### PR DESCRIPTION
Update the aggregator API to send all forwarded http request traffic using an aggregator admin port connection.

Changes consume https://github.com/rapid7/metasploit-aggregator/pull/3

This implementation currently polls the aggregator for requests destined for the console connected due to limitations in the MsgPack-RPC implementation.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfaggregator` in separate shell
- [ ] Start `msfconsole`
- [ ] `load aggregator`
- [ ] **Verify** `aggregator_connect 127.0.0.1:2447`
- [ ] **Verify** `aggregator_default_forward`
- [ ] **Verify** `aggregator_cable_add host:port pem.file(optional)`
newly listening ports will be reported on stderr of the msfaggregator process
- [ ] **Verify** `aggregator_cables`
will report the newly listening cable
- [ ] **Verify** start a https meterpreter session to host:port of a listening cable
this should produce a session on the default registered console
- [ ] **Verify** start a paranoid https meterpreter session to host:port based on pem.file
if the pem.file was used to start the cable this will produce a session
otherwise the meterpreter process should disconnect
- [ ] **Verify** `aggregator_session_park <session_id>`
- [ ] **Verify** `aggregator_sessions <session_id>`
- [ ] **Verify** `aggregator_session_forward <uri_from_sessions_above>`
- [ ] **Verify** `aggregator_disconnect`
